### PR TITLE
Added condition to use source branch stdlib if on CI #82

### DIFF
--- a/src/com/mani/lang/core/Interpreter.java
+++ b/src/com/mani/lang/core/Interpreter.java
@@ -391,7 +391,14 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
                 return "Already loaded!";
             } else {
                 try {
-                    URL url = new URL("https://raw.githubusercontent.com/crazywolf132/Mani/master/stdlib/" + (String) result + ".mni");
+                    String stdlibURL = "https://raw.githubusercontent.com/crazywolf132/Mani/master/stdlib/";
+                    if ("true".equals(System.getenv("CI"))){
+                        String sourceUser = System.getenv("CIRCLE_PROJECT_USERNAME");
+                        String sourceRepo = System.getenv("CIRCLE_PROJECT_REPONAME");
+                        String sourceBranch = System.getenv("CIRCLE_BRANCH");
+                        stdlibURL = "https://raw.githubusercontent.com/" + sourceUser + "/" + sourceRepo + "/" + sourceBranch + "/stdlib/";
+                    }
+                    URL url = new URL(stdlibURL + (String) result + ".mni");
                     Scanner s = new Scanner(url.openStream());
                     String final_file = "";
                     while(s.hasNextLine()){

--- a/src/com/mani/lang/core/Interpreter.java
+++ b/src/com/mani/lang/core/Interpreter.java
@@ -391,14 +391,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
                 return "Already loaded!";
             } else {
                 try {
-                    String stdlibURL = "https://raw.githubusercontent.com/crazywolf132/Mani/master/stdlib/";
-                    if ("true".equals(System.getenv("CI"))){
-                        String sourceUser = System.getenv("CIRCLE_PROJECT_USERNAME");
-                        String sourceRepo = System.getenv("CIRCLE_PROJECT_REPONAME");
-                        String sourceBranch = System.getenv("CIRCLE_BRANCH");
-                        stdlibURL = "https://raw.githubusercontent.com/" + sourceUser + "/" + sourceRepo + "/" + sourceBranch + "/stdlib/";
-                    }
-                    URL url = new URL(stdlibURL + (String) result + ".mni");
+                    URL url = new URL(Mani.getStdLibURL() + (String) result + ".mni");
                     Scanner s = new Scanner(url.openStream());
                     String final_file = "";
                     while(s.hasNextLine()){

--- a/src/com/mani/lang/main/Mani.java
+++ b/src/com/mani/lang/main/Mani.java
@@ -53,6 +53,23 @@ public class Mani {
     }
 
     /**
+     * Gets a stdlib url based on the repo/branch it is being run from
+     * If not on CI, will use default origin master repo for stdlib
+     *
+     * @return the url beneath which stdlib is found
+     */
+    public static String getStdLibURL() {
+        String stdlibURL = "https://raw.githubusercontent.com/Mani-Language/Mani/master/stdlib/";
+        if ("true".equals(System.getenv("CI"))){
+            String sourceUser = System.getenv("CIRCLE_PROJECT_USERNAME");
+            String sourceRepo = System.getenv("CIRCLE_PROJECT_REPONAME");
+            String sourceBranch = System.getenv("CIRCLE_BRANCH");
+            stdlibURL = "https://raw.githubusercontent.com/" + sourceUser + "/" + sourceRepo + "/" + sourceBranch + "/stdlib/";
+        }
+        return stdlibURL;
+    }
+
+    /**
      * Used to figure out if we are connected to the internet or not.
      *
      * @return internetStatus (boolean)
@@ -227,7 +244,7 @@ public class Mani {
         System.err.println(error.getMessage());
     }
 
-    
+
 
 
 


### PR DESCRIPTION
---
Name: Condition to use stdlib from source branch when testing on CI
About: I have added a check when it is on CI to use the source branch.
---

**Is your PR related to a feature request or Bug report?**
If applicable, please list feature request number or bug report ID.
> #82

**Describe your PR**
A clear and concise description of what your pull request is changing or adding.
> Added a check that it is on CI and if so will use the source branch as location for stdlib. If it cannot recognize that it is on CI, it will continue to use the default mani-language/Mani/master branch. Offline mode has not been changed

**Describe intended use**
A clear and concise description of the intended use of the feature. Along with example code.
> Any changes made to stdlib should now be present in tests on that branch. This mostly affects tests run on pull requests

**Is it in the form of a library**
 - [x] No

**Does your PR replace an existing system**
If applicable, please describe how this PR changes the use of a related item.
> Replaces connecting to the main repo master branch by default and will instead use the source branch.
