### PR TITLE
Added fatJar to load stdlib files from within the Jar if not connected to the Internet #82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ task buildCompiler(type: Jar) {
 }
 
 task fatJar(type: Jar) {
+    version 'FatJar'
     manifest {
         attributes 'Main-Class': 'com.mani.lang.main.Mani'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,6 @@ task buildCompiler(type: Jar) {
 }
 
 task fatJar(type: Jar) {
-    version 'FatJar'
     manifest {
         attributes 'Main-Class': 'com.mani.lang.main.Mani'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,26 @@ task buildCompiler(type: Jar) {
     }
 }
 
+task fatJar(type: Jar) {
+    version 'FatJar'
+    manifest {
+        attributes 'Main-Class': 'com.mani.lang.main.Mani'
+    }
+    from {
+        configurations.compile.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+    with jar
+    sourceSets {
+        main {
+            into 'stdlib', {
+                from 'stdlib'
+            }
+        }
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/test/runTestsOffline.mni
+++ b/test/runTestsOffline.mni
@@ -1,0 +1,54 @@
+load "std";
+load "system";
+
+online(false);
+load "basics.mni";
+if (hadError()) { exit(1); }
+
+wipeMemory();
+load "std";
+load "system";
+online(false);
+load "files.mni";
+if (hadError()) { exit(1); }
+
+wipeMemory();
+load "std";
+load "system";
+online(false);
+load "asOperator.mni";
+if (hadError()) { exit(1); }
+
+wipeMemory();
+load "std";
+load "system";
+online(false);
+load "forEach.mni";
+if (hadError()) { exit(1); }
+
+wipeMemory();
+load "std";
+load "system";
+online(false);
+load "lists.mni";
+if (hadError()) { exit(1); }
+
+wipeMemory();
+load "std";
+load "system";
+online(false);
+load "maps.mni";
+if (hadError()) { exit(1); }
+
+//wipeMemory();
+//load "std";
+//load "system";
+//load "atomic.mni";
+//if (hadError()) { exit(1); }
+
+wipeMemory();
+load "std";
+load "system";
+online(false);
+load "math.mni";
+if (hadError()) { exit(1); }

--- a/tests.sh
+++ b/tests.sh
@@ -5,3 +5,12 @@ clear
 cp -r ./test/* ./build/libs
 cd ./build/libs
 java -jar Mani-Stable.jar runTests.mni
+
+cd ../../
+gradle clean
+clear
+gradle fatJar
+clear
+cp -r ./test/* ./build/libs
+cd ./build/libs
+java -jar Mani-Stable.jar runTestsOffline.mni

--- a/tests.sh
+++ b/tests.sh
@@ -13,4 +13,4 @@ gradle fatJar
 clear
 cp -r ./test/* ./build/libs
 cd ./build/libs
-java -jar Mani-Stable.jar runTestsOffline.mni
+java -jar Mani-FatJar.jar runTestsOffline.mni


### PR DESCRIPTION
---
Name: Fat jar including stdlib files
About: Adds a gradle job to add stdlib files to the jar when building
---

**Is your PR related to a feature request or Bug report?**
If applicable, please list feature request number or bug report ID.
> #82 

**Describe your PR**
A clear and concise description of what your pull request is changing or adding.
> Adds a new gradle job which includes stdlib files in a directory in the Jar. Changes the way stdlib files are loaded when not connected to the internet to instead load them from stdlib.

**Describe intended use**
A clear and concise description of the intended use of the feature. Along with example code.
> run ```gradle fatJar```. Disabling internet connection and running Máni using this jar will cause it to instead use the stdlib from within the jar.

**Is it in the form of a library**
 - [x] No
 
**Does your PR replace an existing system**
If applicable, please describe how this PR changes the use of a related item.
> Previously, when not connected to the internet, stdlib was loaded from a fixed location on the users machine. Now, it will instead load it from the location within the .jar file.

**Additional comments**
Add any additional comments or screenshots here.
> @crazywolf132 This changes the behavior so using stdlib with the normal jar without internet is no longer possible. I can add an appropriate message to be thrown if a user tries to do this?