### PR TITLE
Added testing for error messages #92

### DIFF
--- a/src/com/mani/lang/Modules/arrays/arrays.java
+++ b/src/com/mani/lang/Modules/arrays/arrays.java
@@ -4,6 +4,7 @@ import com.mani.lang.core.Interpreter;
 import com.mani.lang.domain.ManiCallable;
 import com.mani.lang.domain.ManiCallableInternal;
 import com.mani.lang.Modules.Module;
+import com.mani.lang.main.Mani;
 import com.mani.lang.main.Std;
 
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ public final class arrays implements Module {
                 if (this.workWith instanceof ArrayList) {
                     if (Std.DoubleToInt((double) arguments.get(0)) > ((ArrayList) this.workWith).size() - 1
                             || Std.DoubleToInt((double) arguments.get(0)) < 0) {
-                        System.err.println("Range must be between 0 and " + (((ArrayList) this.workWith).size() - 1));
+                        Mani.printAndStoreError("Range must be between 0 and " + (((ArrayList) this.workWith).size() - 1));
                         return null;
                     }
                     return ((ArrayList) this.workWith).get(Std.DoubleToInt((double) arguments.get(0)));
@@ -87,7 +88,7 @@ public final class arrays implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.get(0) instanceof Double)) {
-                    System.err.println("Position must be a number!");
+                    Mani.printAndStoreError("Position must be a number!");
                     return null;
                 }
                 return ((ArrayList) this.workWith).remove(Std.DoubleToInt((double) arguments.get(0)));
@@ -123,7 +124,7 @@ public final class arrays implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.get(0) instanceof Double)) {
-                    System.err.println("Size must be a number");
+                    Mani.printAndStoreError("Size must be a number");
                     return null;
                 }
                 List<Object> fin = new ArrayList<>();

--- a/src/com/mani/lang/Modules/downloader/downloader.java
+++ b/src/com/mani/lang/Modules/downloader/downloader.java
@@ -4,6 +4,7 @@ import com.mani.lang.core.Interpreter;
 import com.mani.lang.domain.ManiCallable;
 import com.mani.lang.domain.ManiFunction;
 import com.mani.lang.Modules.Module;
+import com.mani.lang.main.Mani;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.*;
@@ -26,7 +27,7 @@ public class downloader implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.size() >= 2)) {
-                    System.err.println("Must be atleast 2 arguments in downloader.");
+                    Mani.printAndStoreError("Must be atleast 2 arguments in downloader.");
                     return null;
                 }
                 final String downloadURL = (String) arguments.get(0);

--- a/src/com/mani/lang/Modules/logger/logger.java
+++ b/src/com/mani/lang/Modules/logger/logger.java
@@ -4,6 +4,7 @@ import com.mani.lang.core.Interpreter;
 import com.mani.lang.domain.ManiCallableInternal;
 import com.mani.lang.Modules.Module;
 import com.mani.lang.domain.ManiCallable;
+import com.mani.lang.main.Mani;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -56,7 +57,7 @@ public class logger implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.get(0) instanceof Double && arguments.get(1) instanceof String)) {
-                    System.err.println("Arguments must be a Number and String");
+                    Mani.printAndStoreError("Arguments must be a Number and String");
                     return null;
                 }
                 ((Logman) this.workWith).logLevel((String) arguments.get(1), ((Double) arguments.get(0)).intValue());
@@ -69,7 +70,7 @@ public class logger implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.get(0) instanceof Double && arguments.get(1) instanceof String)) {
-                    System.err.println("Arguments must be a Number and String");
+                    Mani.printAndStoreError("Arguments must be a Number and String");
                     return null;
                 }
                 ((Logman) this.workWith).logLevel((String) arguments.get(1), ((Double) arguments.get(0)).intValue(), "\r");
@@ -82,7 +83,7 @@ public class logger implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.get(0) instanceof String)) {
-                    System.err.println("Argument must be a String");
+                    Mani.printAndStoreError("Argument must be a String");
                     return null;
                 }
                 String result;
@@ -107,7 +108,7 @@ public class logger implements Module {
                     result = "Finished writing";
 
                 } catch (FileNotFoundException e) {
-                   System.out.println("Could not write to file!");
+                    Mani.printAndStoreError("Could not write to file!");
                    return e.getMessage();
                 }
                 return result;
@@ -242,7 +243,7 @@ public class logger implements Module {
             msg += "\t|\t";
             msg += message;
 
-            System.err.print(msg);
+            Mani.printAndStoreError(msg);
             this.records.add(msg + "\n");
             return msg;
         }

--- a/src/com/mani/lang/Modules/maps/maps_arraysToMap.java
+++ b/src/com/mani/lang/Modules/maps/maps_arraysToMap.java
@@ -2,6 +2,7 @@ package com.mani.lang.Modules.maps;
 
 import com.mani.lang.core.Interpreter;
 import com.mani.lang.domain.ManiCallable;
+import com.mani.lang.main.Mani;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,7 +24,7 @@ public final class maps_arraysToMap implements ManiCallable {
         ArrayList<Object> first = (ArrayList<Object>) arguments.get(0);
         ArrayList<Object> second = (ArrayList<Object>) arguments.get(1);
         if (first.size() != second.size()) {
-            System.err.println("Please make sure both arrays are the same size.");
+            Mani.printAndStoreError("Please make sure both arrays are the same size.");
             return "Please make sure both arrays are the same size.";
         }
         for (int i = 0; i < first.size(); i++) {

--- a/src/com/mani/lang/Modules/sockets/new_socket.java
+++ b/src/com/mani/lang/Modules/sockets/new_socket.java
@@ -2,6 +2,7 @@ package com.mani.lang.Modules.sockets;
 
 import com.mani.lang.core.Interpreter;
 import com.mani.lang.domain.ManiCallable;
+import com.mani.lang.main.Mani;
 import com.mani.lang.main.Std;
 import com.mani.lang.local.Locals;
 import io.socket.client.IO;
@@ -25,7 +26,7 @@ public class new_socket implements ManiCallable {
             }
 
             if (!(Locals.getType(arguments.get(1)).equals("map"))) {
-                System.err.println("Map expected in second argument");
+                Mani.printAndStoreError("Map expected in second argument");
                 return null;
             }
             IO.Options options = parseOptions((HashMap<Object, Object>) arguments.get(1));

--- a/src/com/mani/lang/Modules/std/std.java
+++ b/src/com/mani/lang/Modules/std/std.java
@@ -4,6 +4,7 @@ import com.mani.lang.core.Interpreter;
 import com.mani.lang.domain.ManiCallable;
 import com.mani.lang.domain.ManiFunction;
 import com.mani.lang.Modules.Module;
+import com.mani.lang.main.Mani;
 import com.mani.lang.main.Std;
 
 import java.util.ArrayList;
@@ -117,6 +118,7 @@ public final class std implements Module{
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 interpreter.wipeMemory();
                 Std.loaded.clear();
+                Mani.hadRuntimeError = false;
                 return null;
             }
         });

--- a/src/com/mani/lang/Modules/system/system.java
+++ b/src/com/mani/lang/Modules/system/system.java
@@ -17,7 +17,7 @@ public class system implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.get(0) instanceof Boolean)) {
-                    System.err.println("Argument must be true or false!");
+                    Mani.printAndStoreError("Argument must be true or false!");
                     return null;
                 }
                 Mani.hasInternet = (Boolean) arguments.get(0);
@@ -32,7 +32,7 @@ public class system implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(arguments.get(0) instanceof Boolean)) {
-                    System.err.println("Argument must be true or false!");
+                    Mani.printAndStoreError("Argument must be true or false!");
                     return null;
                 }
                 Mani.compiledMode = (Boolean) arguments.get(0);
@@ -49,7 +49,7 @@ public class system implements Module {
 //            @Override
 //            public Object call(Interpreter interpreter, List<Object> arguments) {
 //                if (!(arguments.get(0) instanceof String)) {
-//                    System.err.println("Argument must be a string!");
+//                    Mani.printAndStoreError("Argument must be a string!");
 //                    return null;
 //                }
 //                Mani.stdlib_path = (String) arguments.get(0);
@@ -66,6 +66,18 @@ public class system implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 return Mani.hadRuntimeError;
+            }
+        });
+
+        interpreter.addSTD("latestError", new ManiCallable() {
+            @Override
+            public int arity() {
+                return 0;
+            }
+
+            @Override
+            public Object call(Interpreter interpreter, List<Object> arguments) {
+                return Mani.latestErrorMsg;
             }
         });
     }

--- a/src/com/mani/lang/Modules/webSocket/webSocket.java
+++ b/src/com/mani/lang/Modules/webSocket/webSocket.java
@@ -5,6 +5,7 @@ import com.mani.lang.domain.ManiCallableInternal;
 import com.mani.lang.domain.ManiFunction;
 import com.mani.lang.Modules.Module;
 import com.mani.lang.local.Locals;
+import com.mani.lang.main.Mani;
 import com.neovisionaries.ws.client.WebSocket;
 import com.neovisionaries.ws.client.WebSocketAdapter;
 import com.neovisionaries.ws.client.WebSocketException;
@@ -81,7 +82,7 @@ public class webSocket implements Module {
                 try {
                     ((WebSocket) this.workWith).connect();
                 } catch (WebSocketException e) {
-                    System.err.println("Could not connect to server!");
+                    Mani.printAndStoreError("Could not connect to server!");
                     return null;
                 }
                 return null;
@@ -125,7 +126,7 @@ public class webSocket implements Module {
             @Override
             public Object call(Interpreter interpreter, List<Object> arguments) {
                 if (!(Locals.getType(arguments.get(0)).equalsIgnoreCase("map"))) {
-                    System.err.println("Argument must be a map!");
+                    Mani.printAndStoreError("Argument must be a map!");
                     return null;
                 }
                 for (Object header : ((HashMap<Object, Object>) arguments.get(0)).keySet()) {

--- a/src/com/mani/lang/core/Interpreter.java
+++ b/src/com/mani/lang/core/Interpreter.java
@@ -336,7 +336,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
         // This is where we need to actually load the file now, or API... depends if the file exists.
         Object res = evaluate(expr.toLoad);
         if (!(res instanceof String)) {
-            System.err.println("Must be presented as a string");
+            Mani.printAndStoreError("Must be presented as a string");
             return null;
         }
         // If we have gotten this far, we should check for a file.
@@ -378,8 +378,8 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
         // This is where we need to import the library from the internet, or local. Depends if there is internet.
         Object result = evaluate(expr.toImport);
         if (!(result instanceof String)) {
-            System.err.println(result.getClass().getSimpleName());
-            System.err.println("Must be presented as a string");
+            Mani.printAndStoreError(result.getClass().getSimpleName());
+            Mani.printAndStoreError("Must be presented as a string");
             return null;
         }
 
@@ -403,7 +403,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
                 catch(IOException ex) {
                     String res = Std.find((String) result);
                     if (res.equalsIgnoreCase("-1")) {
-                        System.err.println("No such library!");
+                        Mani.printAndStoreError("No such library!");
                     } else {
                         return Std.loadFile(this, res);
                     }
@@ -417,7 +417,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
             }
             String res = Std.find((String) result);
             if (res.equalsIgnoreCase("-1")) {
-                System.err.println("No such library!");
+                Mani.printAndStoreError("No such library!");
             } else if (res.equalsIgnoreCase("-2")) {
                 return "Already loaded!";
             } else {
@@ -562,7 +562,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
                 if (Locals.canConvert(left, right)) {
                     return Locals.convert(left, right.toString());
                 }
-                System.err.println("Cannot convert to that type!");
+                Mani.printAndStoreError("Cannot convert to that type!");
                 return null;
         }
         return null;

--- a/src/com/mani/lang/main/Mani.java
+++ b/src/com/mani/lang/main/Mani.java
@@ -27,6 +27,8 @@ public class Mani {
     public static boolean isStrictMode = false;
     public static boolean compiledMode = false;
 
+    public static String latestErrorMsg = null;
+
     private static final Interpreter interpreter = new Interpreter();
 
     /**
@@ -103,12 +105,12 @@ public class Mani {
                 run(new String(bytes, Charset.defaultCharset()), fileName);
                 if(hadError) System.exit(65);
             } catch(NoSuchFileException e) {
-                System.out.println(path + ": File not Found");
+                printAndStoreError(path + ": File not Found");
             } catch(IOException e) {
-                System.out.println(e.getMessage());
+                printAndStoreError(e.getMessage());
             }
         } else {
-            System.err.println("Mani scripts must end with '.mni'.");
+            printAndStoreError("Mani scripts must end with '.mni'.");
         }
     }
 
@@ -127,7 +129,7 @@ public class Mani {
                 hadError = false;
             }
         } catch(IOException e) {
-            System.err.println(e.getMessage());
+            printAndStoreError(e.getMessage());
         }
     }
 
@@ -232,7 +234,7 @@ public class Mani {
      * @param message
      */
     private static void report(int line, String where, String message) {
-        System.err.println("[line " + line + "] Error " + where +" : " + message );
+        printAndStoreError("[line " + line + "] Error " + where +" : " + message );
         hadError = true;
     }
 
@@ -242,16 +244,18 @@ public class Mani {
      * @param error
      */
     public static void runtimeError(RuntimeError error) {
-        System.err.println(error.getMessage() + "\n[line " + error.token.line + "] at " + error.token.file);
+        printAndStoreError(error.getMessage() + "\n[line " + error.token.line + "] at " + error.token.file);
         hadRuntimeError = true;
     }
 
     public static void generalError(GeneralError error) {
-        System.err.println(error.getMessage());
+        printAndStoreError(error.getMessage());
     }
 
-
-
+    public static void printAndStoreError(String errorMsg) {
+        latestErrorMsg = errorMsg;
+        System.err.println(errorMsg);
+    }
 
 
 }

--- a/test/errorScript.mni
+++ b/test/errorScript.mni
@@ -1,0 +1,10 @@
+/*
+Script designed to throw an error
+*/
+
+//Import lists library
+# "files";
+
+
+// This line should throw an error
+let f = File();

--- a/test/runTests.mni
+++ b/test/runTests.mni
@@ -25,6 +25,14 @@ if (hadError()) { exit(1); }
 wipeMemory();
 load "std";
 load "system";
+// Script intended to throw error
+load "errorScript.mni";
+// Tests that error was output correctly
+load "testErrorOutputs.mni";
+
+wipeMemory();
+load "std";
+load "system";
 load "lists.mni";
 if (hadError()) { exit(1); }
 

--- a/test/runTestsOffline.mni
+++ b/test/runTestsOffline.mni
@@ -30,6 +30,15 @@ wipeMemory();
 load "std";
 load "system";
 online(false);
+// Script intended to throw error
+load "errorScript.mni";
+// Tests that error was output correctly
+load "testErrorOutputs.mni";
+
+wipeMemory();
+load "std";
+load "system";
+online(false);
 load "lists.mni";
 if (hadError()) { exit(1); }
 

--- a/test/testErrorOutputs.mni
+++ b/test/testErrorOutputs.mni
@@ -1,0 +1,13 @@
+/*
+Tests that the error output is as expected
+*/
+
+
+load "munit";
+
+let t <- newTester();
+t.header("Assert error outputs");
+
+t.assertEquals(latestError(), "Expected 1 argument(s) but got 0." + NL + "[line 10] at errorScript.mni", "Error thrown as epected");
+
+t.results();


### PR DESCRIPTION
---
Name: Tests for error messages
About: Redirected all calls to System.out.err through a new function which will store the latest error message. This allows for testing that a specific error message was thrown
---

**Is your PR related to a feature request or Bug report?**
If applicable, please list feature request number or bug report ID.
> #92 

**Describe your PR**
A clear and concise description of what your pull request is changing or adding.
> Adds testing for error messages to assert they are thrown as expected

**Describe intended use**
A clear and concise description of the intended use of the feature. Along with example code.
> Whenever displaying an error message using ```System.err.println(errMsg)```, instead use ```Mani.printAndStoreError(errMsg)```. This will still print the error message but will also store the latest message so it can be verified by tests.

**Is it in the form of a library**
 - [x] No
