### PR TITLE
Add support for string tokentype in switch-case

### DIFF
--- a/src/com/mani/lang/core/Parser.java
+++ b/src/com/mani/lang/core/Parser.java
@@ -275,8 +275,8 @@ public class Parser {
                 if (seenDefault) {
                     throw new Return("Default has already been declared.");
                 }
-                Token number = consume(TokenType.NUMBER, "Expect number in case");
-                literals.add(number.literal);
+                Token token = consume(TokenType.NUMBER, TokenType.STRING, "Expect number or string in case");
+                literals.add(token.literal);
                 consume(TokenType.COLON, "Expect colon");
                 statements.add(new ArrayList<>());
                 continue;

--- a/test/switchCase.mni
+++ b/test/switchCase.mni
@@ -56,3 +56,36 @@ switch (a) {
 		myList.add(100);
 }
 t.assertEquals(myList.list, [1,2,3,0,0,3,30,0,100], "Add item to list");
+
+//Create a new list for strings
+let myStringList = List();
+
+// Simple single statement per-case.
+let var = "b";
+switch (var) {
+	case "a" :
+		myStringList.add("a");
+	case "b" :
+		myStringList.add("b");
+	case "c" :
+		myStringList.add("c");
+	default :
+		myStringList.add("default");
+}
+t.assertEquals(myStringList.list, [b, c, default], "Add item to list");
+
+// When switch variable is of number type, but cases are for string type, it
+// does not complain about type-mismatch and easily compiles. The default
+// block gets executed. Same behaviour is observered for the vice-versa case.
+let var = 1;
+switch (var) {
+	case "a" :
+		myStringList.add("a");
+	case "b" :
+		myStringList.add("b");
+	case "c" :
+		myStringList.add("c");
+	default :
+		myStringList.add("default");
+}
+t.assertEquals(myStringList.list, [b, c, default, default], "Add item to list");


### PR DESCRIPTION
---
name: support for string tokentype in switch-case
about: I have added support for string tokentype in switch-case to the language.
---

**Is your PR related to a feature request or Bug report?**
If applicable, please list feature request number or bug report ID.
> It is an improvement of the existing feature (#79).

**Describe your PR**
A clear and concise description of what your pull request is changing or adding.
> It is adding support for string tokentype in switch-case.

**Describe intended use**
A clear and concise description of the intended use of the feature. Along with example code.
> Now, switch variable can also be a string. Earlier, it could only be a number.
```
let var = "b";
switch (var) {
	case "a" :
		// do something.
	case "b" :
		// do something else.
	case "c" :
		// do something more.
	default :
		// do default stuff.
}
```

**How did you fix the bug?**
If applicable, how did you fix the bug? Please use code snippets too.
> Added TokenType.STRING in the parsing phase.

**Is it in the form of a library**
 - No
 
If applicable what is the library called?
> N/A.

**Does your PR replace an existing system**
If applicable, please describe how this PR changes the use of a related item.
> No.

**Additional comments**
Add any additional comments or screenshots here.